### PR TITLE
Simplify one lambda

### DIFF
--- a/util/logger.js
+++ b/util/logger.js
@@ -1,14 +1,12 @@
 'use strict';
 const winston = require('winston');
 
-module.exports.createLogger = (serviceName) => {
-	return winston.createLogger({
-		level: 'info',
-		format: winston.format.json(),
-		defaultMeta: { service: serviceName },
-		transports: [
-			new winston.transports.File({ filename: 'error.log', level: 'error' }),
-			new winston.transports.File({ filename: 'combined.log' })
-		]
-	});
-};
+module.exports.createLogger = (serviceName) => winston.createLogger({
+	level: 'info',
+	format: winston.format.json(),
+	defaultMeta: { service: serviceName },
+	transports: [
+		new winston.transports.File({ filename: 'error.log', level: 'error' }),
+		new winston.transports.File({ filename: 'combined.log' })
+	]
+});


### PR DESCRIPTION
In the `createLogger` function in `logger.js`, this PR adjusts the syntax to not require the `return` keyword. It would be a one-line patch if I didn't also have to fix the indentation of the lambda now that it's not embedded in a block.

This is hardly worth a separate PR, but when I embarked on it I expected to find other cases or other over-complex syntax instances, and I was pleased to find only the one.